### PR TITLE
Fix redirect paths for API and auth endpoints to ensure trailing slashes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,7 +12,7 @@ function App() {
         fetch("/api/")
             .then((response) => {
                 if (response.status === 401) {
-                    location.assign("/auth");
+                    location.assign("/auth/");
                 }
             })
             .catch((error) => {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,10 @@
 server {
     listen 80;
 
+    location /api {
+        return 301 /api/;
+    }
+
     location /api/ {
         proxy_pass http://backend:8080/api/;
         proxy_set_header Host $host;
@@ -13,6 +17,10 @@ server {
 
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
+    }
+
+    location /auth {
+        return 301 /auth/;
     }
 
     location /auth/ {


### PR DESCRIPTION
This pull request includes changes to the frontend and the Nginx configuration to ensure consistent URL redirection for the `/auth` and `/api` endpoints.

Frontend changes:

* [`frontend/src/App.jsx`](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L15-R15): Updated the URL redirection for unauthorized access to use `/auth/` instead of `/auth`.

Nginx configuration changes:

* [`nginx/nginx.conf`](diffhunk://#diff-4adaaefa7fc959e7dfe65e8dc8dadc9ee27ddd284eee3426463b1cdc000587d5R4-R7): Added a new location block to redirect `/api` to `/api/` with a 301 status code.
* [`nginx/nginx.conf`](diffhunk://#diff-4adaaefa7fc959e7dfe65e8dc8dadc9ee27ddd284eee3426463b1cdc000587d5R22-R25): Added a new location block to redirect `/auth` to `/auth/` with a 301 status code.